### PR TITLE
Save Session File -- No Prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
           "dfdl"
         ],
         "extensions": [
-          "dfdl.xsd"
+          ".xsd",
+          ".xml"
         ],
         "configuration": "./language/dfdl.json"
       }

--- a/src/omega_edit/client-exp.ts
+++ b/src/omega_edit/client-exp.ts
@@ -31,6 +31,7 @@ import {
 import { startServer, stopServer } from './server'
 import { client, randomId } from './utils/settings'
 import * as hexy from 'hexy'
+import { getFilePath } from './utils/misc'
 
 let serverRunning = false
 
@@ -121,11 +122,11 @@ export function activate(ctx: vscode.ExtensionContext) {
               })
               return
             case 'save':
-              let filePath = message.overwrite
-                ? message.sessionFile
-                : await vscode.window.showInputBox({
-                    placeHolder: 'Save session as:',
-                  })
+              let filePath = await getFilePath(
+                message.sessionFile,
+                message.overwrite,
+                message.newFile
+              )
 
               if (filePath) {
                 let rootPath = vscode.workspace.workspaceFolders

--- a/src/omega_edit/client.ts
+++ b/src/omega_edit/client.ts
@@ -31,6 +31,7 @@ import {
 } from './utils/viewport'
 import { startServer, stopServer } from './server'
 import { client, randomId } from './utils/settings'
+import { getFilePath } from './utils/misc'
 
 let serverRunning = false
 
@@ -69,7 +70,6 @@ export function activate(ctx: vscode.ExtensionContext) {
         }
       )
 
-      // panel.webview.html = getWebviewContent(uri)
       panel.webview.html = getWebviewContent(ctx)
 
       let fileToEdit = await vscode.window
@@ -90,7 +90,6 @@ export function activate(ctx: vscode.ExtensionContext) {
         command: 'setSessionFile',
         filePath: fileToEdit,
       })
-      // panel.webview.postMessage({ command: 'session', text: s })
 
       let vpin = await createViewport(randomId().toString(), s, 0, 1000)
       let vp1 = await createViewport(randomId().toString(), s, 0, 64)
@@ -128,11 +127,11 @@ export function activate(ctx: vscode.ExtensionContext) {
               })
               return
             case 'save':
-              let filePath = message.overwrite
-                ? message.sessionFile
-                : await vscode.window.showInputBox({
-                    placeHolder: 'Save session as:',
-                  })
+              let filePath = await getFilePath(
+                message.sessionFile,
+                message.overwrite,
+                message.newFile
+              )
 
               if (filePath) {
                 let rootPath = vscode.workspace.workspaceFolders
@@ -241,8 +240,14 @@ function getWebviewContent(ctx: vscode.ExtensionContext) {
       <input type="checkbox" id="overwriteSessionFile">
       <span class="checkmark"></span>
     </label>
-    <button id="save" class="save-button" type="button" onclick="saveSession()">Save Session</button>
   </div>
+  <div class="setting-div" style="margin-top: 10px;" onclick="check('saveNewSessionFile')">
+    <label class="container">Save As New File (no-prompt)
+      <input type="checkbox" id="saveNewSessionFile">
+      <span class="checkmark"></span>
+    </label>
+  </div>
+  <button id="save" class="save-button" type="button" onclick="saveSession()">Save Session</button>
   <script>
       ${scriptData}
   </script>

--- a/src/omega_edit/scripts/omega_edit.js
+++ b/src/omega_edit/scripts/omega_edit.js
@@ -21,6 +21,20 @@ const vscode = acquireVsCodeApi()
 function check(elementId) {
   const element = document.getElementById(elementId)
   element.checked = element.checked ? false : true
+
+  if (elementId == 'overwriteSessionFile') {
+    const newFileElement = document.getElementById('saveNewSessionFile')
+
+    if (newFileElement.checked && element.checked) {
+      newFileElement.checked = false
+    }
+  } else if (elementId == 'saveNewSessionFile') {
+    const overwriteElement = document.getElementById('overwriteSessionFile')
+
+    if (overwriteElement.checked && element.checked) {
+      overwriteElement.checked = false
+    }
+  }
 }
 
 function sendit(value) {
@@ -35,6 +49,7 @@ function saveSession() {
     command: 'save',
     sessionFile: document.getElementById('sessionFile').value,
     overwrite: document.getElementById('overwriteSessionFile').checked,
+    newFile: document.getElementById('saveNewSessionFile').checked,
   })
 }
 

--- a/src/omega_edit/utils/misc.ts
+++ b/src/omega_edit/utils/misc.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomId } from './settings'
+import * as vscode from 'vscode'
+
+export async function getFilePath(
+  sessionFile: string,
+  overwrite: boolean,
+  newFile: boolean
+): Promise<string | undefined> {
+  // Get file path for saved file
+  let filePath: string | undefined
+
+  if (overwrite) {
+    filePath = sessionFile
+  } else if (newFile) {
+    let fileName = sessionFile.split('/')[sessionFile.split('/').length - 1]
+    let path = sessionFile.replace(`/${fileName}`, '')
+    let fileNameStart = fileName
+      .split('.')
+      .slice(0, fileName.split('.').length - 1)
+      .join('')
+    let fileNameEnd = fileName.split('.')[fileName.split('.').length - 1]
+    filePath = `${path}/${fileNameStart}-${randomId().toString()}.${fileNameEnd}`
+  } else {
+    filePath = await vscode.window.showInputBox({
+      placeHolder: 'Save session as:',
+    })
+  }
+
+  return filePath
+}


### PR DESCRIPTION
- Add option to editor UI to not prompt for file name to save to
  - This is a button with the text `Save As New File (no-promt)`
  - When selected the editor saves the session as a new file that has the same base name as the session file but with a random ID added to it
    - Example:
    ```
    sessionFile = "/Users/sdell/sampleWorkspace/.vscode/launch.json"
    newFile = "/Users/sdell/sampleWorkspace/.vscode/launch-199.json"
    ```
- Also updated the dfdl language extension to support `.xsd` and `.xml` instead of only `.dfdl.xsd`

Closes #13